### PR TITLE
2 - remove importlib calls for the dataHandler

### DIFF
--- a/job_exec/dataHandler.py
+++ b/job_exec/dataHandler.py
@@ -2,8 +2,9 @@
 from typing import Dict, Any
 import importlib
 
-from dataStrategies.baseStrategy import BaseDataStrategy
+from dataStrategies.baseStrategy import BaseDataStrategy, DictOfDictStrategy
 from configClasses.baseConfig import BaseConfig
+from dataStrategies.sqlStrategy import SQLStrategy
 
 class DataHandler:
     def __init__(self, config: BaseConfig):
@@ -37,14 +38,9 @@ class DataHandler:
                 + " Please set an appropriate value in the config file in" 
                 + " section 'jobdb', keyword 'type'.")
         elif self.strategy_type in ["dummy","dictofdict"]:
-            module = importlib.import_module(f"dataStrategies.baseStrategy")
-            return getattr(module,"DictOfDictStrategy")
-        #elif self.strategy_type == "csv":
-        #    module = importlib.import_module(f"dataStrategies.csvStrategy")
-        #    return getattr(module,"CSVStrategy")
+            return DictOfDictStrategy
         elif self.strategy_type in ["sqlite","mysql","sql"]:
-            module = importlib.import_module(f"dataStrategies.sqlStrategy")
-            return getattr(module,"SQLStrategy")
+            return SQLStrategy
 
     # Defining the interface to interact with the dataStrategies:
     # - enable context management via __enter__ and __exit__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "EFIJobExecutor"
-version = "0.0.1"
+version = "0.0.2"
 authors = [
   { name="Russell B. Davidson", email="rbdavid@illinois.edu" },
   { name="Nils Oberg", email="noberg@illinois.edu" },


### PR DESCRIPTION
Closes issue #2. Changes made because dynamic importing should only be used when strategies are projected to be really diverse. That's not the case for dataStrategies. The DictofDict strategy is only implemented for testing/dummy purposes. All real world scenarios will use a SQL table to hold information about EFI jobs, so the sqlStrategy code will be used.