### PR TITLE
4 implement full job class

### DIFF
--- a/job_exec/constants.py
+++ b/job_exec/constants.py
@@ -19,7 +19,7 @@ class Status(Flag):
         return self.name.lower()
 
     @classmethod
-    def getStatus(self, status_str: str):
+    def getFlag(self, status_str: str):
         if status_str is None:
             return None
         return getattr(self, status_str.upper(), None)

--- a/job_exec/constants.py
+++ b/job_exec/constants.py
@@ -1,4 +1,5 @@
 
+from typing import Union
 from enum import Flag, auto
 
 class Status(Flag):
@@ -19,9 +20,17 @@ class Status(Flag):
         return self.name.lower()
 
     @classmethod
-    def getFlag(self, status_str: str):
-        if status_str is None:
-            return None
-        return getattr(self, status_str.upper(), None)
-
+    def getFlag(cls, status: Union[int, str]):
+        try:
+            if type(status) == int:
+                return cls(status)
+            elif type(status) == str:
+                return getattr(cls, status.upper())
+            else:
+                raise ValueError(f"Given status value ({status}) is" 
+                    + " incorrectly typed.")
+        except (ValueError, AttributeError) as e:
+            print(f"Given status value ({status}) does not match a Status" 
+                + f" Flag.\n{e}")
+            raise
 

--- a/job_exec/dataStrategies/sqlStrategy.py
+++ b/job_exec/dataStrategies/sqlStrategy.py
@@ -26,11 +26,11 @@ class SQLStrategy(BaseDataStrategy):
         self.Session: Optional[sqlalchemy.orm.sessionmaker] = None
         self.session: Optional[sqlalchemy.orm.Session] = None
 
+        # NOTE: UPDATE THIS LIST TO MATCH THE INHERITANCE CLASSES
         self.updatable_attrs = [
             "status",
             "timeStarted",
             "timeCompleted",
-            "results"
         ]
 
     def create_db_url(self) -> str:

--- a/job_exec/jobModels/job_dummy_orm.py
+++ b/job_exec/jobModels/job_dummy_orm.py
@@ -1,9 +1,10 @@
 
 from datetime import datetime
+from enum import Flag
 
 import sqlalchemy
 
-from sqlalchemy import String, DateTime, func
+from sqlalchemy import String, func
 from sqlalchemy.orm import DeclarativeBase, mapped_column, Mapped
 from sqlalchemy.types import TypeDecorator
 
@@ -25,7 +26,7 @@ class FlagEnumType(TypeDecorator):
         self.enum_class = enum_class
         super().__init__(*args, **kwargs)
 
-    def process_bind_param(self, value: Status, dialect):
+    def process_bind_param(self, value: Flag, dialect) -> str:
         """ 
         Overwrite TypeDecorator.process_bind_param() method to implement custom
         handling for this object. Documentation:
@@ -37,7 +38,7 @@ class FlagEnumType(TypeDecorator):
         """
         return value.__str__()
 
-    def process_result_value(self, value, dialect):
+    def process_result_value(self, value, dialect) -> Flag:
         """
         Overwrite TypeDecorator.process_result_value() method to implement 
         custom handling for this object. Documentation:
@@ -47,8 +48,6 @@ class FlagEnumType(TypeDecorator):
         python type, in this case a Flag object (e.g. "queued" in the DB is 
         converted to Status.QUEUED)
         """
-        if value is None:
-            return None
         return self.enum_class.getFlag(value)
 
 class Base(DeclarativeBase):

--- a/job_exec/jobModels/job_dummy_orm.py
+++ b/job_exec/jobModels/job_dummy_orm.py
@@ -49,7 +49,7 @@ class FlagEnumType(TypeDecorator):
         """
         if value is None:
             return None
-        return self.enum_class.getStatus(value)
+        return self.enum_class.getFlag(value)
 
 class Base(DeclarativeBase):
     ## can do a whole bunch of stuff in this class before passing it on to 
@@ -102,9 +102,3 @@ class Job(Base):
                 + f" {completed_string})>")
 
 
-# from efi-web:
-# migrations/Version20250514011931.php
-#       $this->addSql('CREATE TABLE Job (id INT AUTO_INCREMENT NOT NULL, user_id INT DEFAULT NULL, uuid CHAR(36) NOT NULL COMMENT \'(DC2Type:guid)\', status VARCHAR(255) NOT NULL, type VARCHAR(255) NOT NULL, timeCreated DATETIME DEFAULT NULL, timeStarted DATETIME DEFAULT NULL, timeCompleted DATETIME DEFAULT NULL, efi_db_version VARCHAR(255) DEFAULT NULL, params JSON DEFAULT NULL COMMENT \'(DC2Type:json)\', results JSON DEFAULT NULL COMMENT \'(DC2Type:json)\', email VARCHAR(255) DEFAULT NULL, isPublic TINYINT(1) NOT NULL, parentJob_id INT DEFAULT NULL, job_type VARCHAR(255) NOT NULL, blastQuery VARCHAR(255) DEFAULT NULL, blastMaxSequences INT DEFAULT NULL, blastDatabase VARCHAR(255) DEFAULT NULL, blastEValue INT DEFAULT NULL, domain TINYINT(1) DEFAULT NULL, domainRegion VARCHAR(255) DEFAULT NULL, inputFasta LONGTEXT DEFAULT NULL, filterByFamilies VARCHAR(255) DEFAULT NULL, accessionIds VARCHAR(255) DEFAULT NULL, domainFamily VARCHAR(255) DEFAULT NULL, filename VARCHAR(255) DEFAULT NULL, sequenceDatabase VARCHAR(255) DEFAULT NULL, exclude_fragments TINYINT(1) DEFAULT NULL, minLength INT DEFAULT NULL, maxLength INT DEFAULT NULL, maxBlastSequences INT DEFAULT NULL, blastSequence LONGTEXT DEFAULT NULL, eValue INT DEFAULT NULL, maxSeqMSA INT DEFAULT NULL, minSeqMSA INT DEFAULT NULL, cooccurrence DOUBLE PRECISION DEFAULT NULL, neighborhood_size INT DEFAULT NULL, referenceDatabase VARCHAR(255) DEFAULT NULL, cdhitSequenceIdentity INT DEFAULT NULL, searchType VARCHAR(255) DEFAULT NULL, minSequenceLength INT DEFAULT NULL, maxSequenceLength INT DEFAULT NULL, allByAllBlastEValue INT DEFAULT NULL, jobName VARCHAR(255) DEFAULT NULL, excludeFragments TINYINT(1) DEFAULT NULL, families VARCHAR(255) DEFAULT NULL, sequence_version VARCHAR(255) DEFAULT NULL, fraction INT DEFAULT NULL, taxSearch VARCHAR(255) DEFAULT NULL, taxSearchName VARCHAR(255) DEFAULT NULL, INDEX IDX_C395A618A76ED395 (user_id), INDEX IDX_C395A6184A4533A0 (parentJob_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
-# migrations/Version2025052614521.php
-#       $this->addSql('ALTER TABLE Job ADD alignmentScore DOUBLE PRECISION DEFAULT NULL, ADD alignmentScoreThreshold DOUBLE PRECISION DEFAULT NULL, ADD computeNeighborhoodConnectivity TINYINT(1) DEFAULT NULL, ADD fastaInput VARCHAR(255) DEFAULT NULL, ADD metagenomes LONGTEXT DEFAULT NULL, DROP params, DROP type, DROP minSequenceLength, DROP maxSequenceLength');
-#       $this->addSql('ALTER TABLE Job ADD params JSON DEFAULT NULL COMMENT \'(DC2Type:json)\', ADD type VARCHAR(255) NOT NULL, ADD minSequenceLength INT DEFAULT NULL, ADD maxSequenceLength INT DEFAULT NULL, DROP alignmentScore, DROP alignmentScoreThreshold, DROP computeNeighborhoodConnectivity, DROP fastaInput, DROP metagenomes');

--- a/job_exec/jobModels/job_efi_web_orm.py
+++ b/job_exec/jobModels/job_efi_web_orm.py
@@ -1,31 +1,34 @@
 
 from datetime import datetime
+from enum import Enum
 
 import sqlalchemy
 
-from sqlalchemy import String, DateTime, func
+from sqlalchemy import func
 from sqlalchemy.orm import DeclarativeBase, mapped_column, Mapped
 from sqlalchemy.types import TypeDecorator
 
 from constants import Status
 
+# NOTE: generalize this to non-Status enums too
 class FlagEnumType(TypeDecorator):
     """ 
     SQLAlchemy does not know how to handle python Enum/Flag values as DB column
-    values. This class is developing the custom handling of a String column 
+    values. This class is developing the custom handling of a str column 
     (stored as a VARCHAR or equivalent) and an associated python Flag object.
 
     This is general code that works for any python Flag Enum, but is intended 
     for the Status object and the status column in the DB. 
     """
-    impl = String   # DB column is implemented as a SQLAlchemy String 
+    impl = str   # DB column is implemented as a SQLAlchemy str 
     cache_ok = True
 
     def __init__(self, enum_class, *args, **kwargs):
         self.enum_class = enum_class
         super().__init__(*args, **kwargs)
 
-    def process_bind_param(self, value: Status, dialect):
+    # NOTE: generalize this to non-Status enums too
+    def process_bind_param(self, value, dialect):
         """ 
         Overwrite TypeDecorator.process_bind_param() method to implement custom
         handling for this object. Documentation:
@@ -44,18 +47,14 @@ class FlagEnumType(TypeDecorator):
         https://docs.sqlalchemy.org/en/20/core/custom_types.html#sqlalchemy.types.TypeDecorator.process_result_value
 
         This is used to convert a result-row column's value to the returned 
-        python type, in this case a Flag object (e.g. "queued" in the DB is 
-        converted to Status.QUEUED)
+        python type, for example a status column value of "queued" in the DB is 
+        converted to Status.QUEUED.
         """
         if value is None:
             return None
-        return self.enum_class.getStatus(value)
+        return self.enum_class.getFlag(value)
 
 class Base(DeclarativeBase):
-    ## can do a whole bunch of stuff in this class before passing it on to 
-    ## inhereting class/tables like explicitly control python types and their 
-    ## associated sqlalchemy types
-    #type_annotation_map = {}
     pass
 
 class Job(Base):
@@ -68,117 +67,597 @@ class Job(Base):
     # enables skipping the `mapped_column()` call. The `Mapped` annotation can
     # be used to set datatype _and_ nullability for the column. Default for 
     # nullable is True for non-primary key columns.
+    
+    # general parameters
     job_id: Mapped[int] = mapped_column("id", primary_key=True)
+    user_id: Mapped[int | None]     # mapped to user_id from the migration files but "user" in the entity files
     uuid: Mapped[str] = mapped_column(nullable=False)
-    user: Mapped[int] = mapped_column("user_id")    # , nullable=False
-    status: Mapped[Status] = mapped_column(FlagEnumType(Status), nullable=False)
-    timeCreated: Mapped[datetime | None] = mapped_column(
-        server_default=func.now()   # NOTE: do I need this???
-    )
+    status: Mapped[str] = mapped_column(nullable=False)
+    #status: Mapped[Status] = mapped_column(FlagEnumType(Status), nullable=False)
+    timeCreated: Mapped[datetime | None]    # should be `= mapped_column(nullable=False)`?
     timeStarted: Mapped[datetime | None]
     timeCompleted: Mapped[datetime | None]
     efi_db_version: Mapped[str | None]
     email: Mapped[str | None]
-    isPublic: Mapped[int] = mapped_column(nullable=False)   # NOTE: Should be boolean?
+    isPublic: Mapped[bool] = mapped_column(nullable=False)
+    isExample: Mapped[bool | None]   # should this be nullable?
     parentJob_id: Mapped[int | None]
-    job_type: Mapped[str] = mapped_column(nullable=False)   # NOTE: change this to an enum
-    
-    results: Mapped[str | None] # NOTE: gonna change?
+    # placeholder columns
+    jobName: Mapped[str | None]      # in symfony, this is associated with ESTGenerateJob
+    results: Mapped[str | None] # NOTE: gonna change
    
-    ### input parameter columns
-    # ESTGenerateJob; EST-general parameters
-    allByAllBlastEValue: Mapped[int | None]    # NOTE: should be a double
-    jobName: Mapped[str | None]     # NOTE: why is this specific to EST? Shouldn't GNT also have a jobName column?
+    job_type: Mapped[str] = mapped_column(nullable=False) # used as the polymorphic_on attribute
+    __mapper_args__ = {
+        "polymorphic_on": "job_type",
+        "polymorphic_identity": "job",
+    }
 
-    # ESTGenerateBlastJob; blast input path
+    #def __repr__(self):
+    #    if self.status in Status.COMPLETED:
+    #        completed_string = f"timeStarted='{self.timeStarted}', timeCompleted='{self.timeCompleted}'"
+    #    elif self.status == Status.RUNNING:
+    #        completed_string = f"timeStarted='{self.timeStarted}'"
+    #    else:
+    #        completed_string = ""
+    #    return (f"<self.__class__.__name__(id={self.job_id}," 
+    #            + f" status='{self.status}'," 
+    #            + f" efi_type='{self.efi_type}'," 
+    #            + f" timeCreated='{self.timeCreated}'" 
+    #            + f" {completed_string})>")
+
+################################################################################
+# Mixin Column Classes
+
+class ProteinFamilyAdditionParameters:
+    families: Mapped[str | None] = mapped_column(
+        use_existing_column=True
+    )
+    sequence_version: Mapped[str | None] = mapped_column(    # NOTE: should this be an enum uniprot, uniref50, uniref90? Is this redundant with blastDatabase?
+        use_existing_column=True
+    )
+    fraction: Mapped[int | None] = mapped_column(    # NOTE: should this be a float? how is this handled on the backend?
+        use_existing_column=True
+    )
+    numUnirefClusters: Mapped[int | None] = mapped_column(
+        use_existing_column=True
+    )
+
+class DomainBoundariesParameters:
+    domain: Mapped[bool | None] = mapped_column(
+        use_existing_column=True
+    )
+    domainRegion: Mapped[str | None] = mapped_column(         # NOTE: should be an enum of "n-terminal", "c-terminal", "central", or "domain"?
+        use_existing_column=True
+    )
+
+class ExcludeFragmentsParameters:
+    excludeFragments: Mapped[bool | None] = mapped_column(
+        use_existing_column=True
+    )
+
+class FilterByTaxonomyParameters:
+    taxSearch: Mapped[str | None] = mapped_column(
+        use_existing_column=True
+    )
+    taxSearchName: Mapped[str | None] = mapped_column(
+        use_existing_column=True
+    )
+
+class FilterByFamiliesParameters:
+    filterByFamilies: Mapped[str | None] = mapped_column(
+        use_existing_column=True
+    )
+
+class UserUploadedIdsParameters:
+    numMatchedIds: Mapped[int | None] = mapped_column(
+        use_existing_column=True
+    )
+    numUnmatchedIds: Mapped[int | None] = mapped_column(
+        use_existing_column=True
+    )
+
+class FilenameParameters:
+    uploadedFilename: Mapped[str | None] = mapped_column(
+        use_existing_column=True
+    )
+
+class SequenceDatabaseParameters:
+    sequenceDatabase: Mapped[str | None] = mapped_column(
+        use_existing_column=True
+    )
+    exclude_fragments: Mapped[bool | None] = mapped_column(
+        use_existing_column=True
+    )
+
+#class ESTGenerateJob(Job, ProteinFamilyAdditionParameters):
+class ESTGenerateJob:
+    """
+    Inherits from Job class, adds ProteinFamilyAdditionParameters since any 
+    EST input path can use those fields. Does not get polymorph'd on.
+    """
+    allByAllBlastEValue: Mapped[int | None] = mapped_column(
+        use_existing_column=True
+    )
+    numFamilyOverlap: Mapped[int | None] = mapped_column( 
+        use_existing_column=True
+    )
+    numNonFamily: Mapped[int | None] = mapped_column( 
+        use_existing_column=True
+    )
+    numUnirefFamilyOverlap: Mapped[int | None] = mapped_column( 
+        use_existing_column=True
+    )
+    numComputedSequences: Mapped[int | None] = mapped_column( 
+        use_existing_column=True
+    )
+    numUniqueSequences: Mapped[int | None] = mapped_column( 
+        use_existing_column=True
+    )
+    numBlastEdges: Mapped[int | None] = mapped_column( 
+        use_existing_column=True
+    )
+    
+    #__mapper_args__ = {
+    #    'polymorphic_abstract=True'
+    #}
+
+#class GNTDiagramJob(Job):
+class GNTDiagramJob:
+    """
+    Inherits from Job class, used as parent class to GNTDiagramBlast, 
+    GNTDiagramFasta, and GNTDiagramSequenceId. Does not get polymorph'd on.
+    """
+    neighborhood_size: Mapped[int | None] = mapped_column(
+        use_existing_column=True
+    )
+    #__mapper_args__ = {
+    #    'polymorphic_abstract=True'
+    #}
+
+#class TaxonomyJob(
+#        Job,
+#        ExcludeFragmentsParameters, 
+#        FilterByFamiliesParameters, 
+#        FilterByTaxonomyParameters,
+#    ):
+#    """
+#    """
+#    __mapper_args__ = {
+#        'polymorphic_abstract=True'
+#    }
+
+###############################################################################
+# polymorphic_identity classes
+
+class ESTGenerateFastaJob(
+        Job, 
+        ProteinFamilyAdditionParameters,
+        ESTGenerateJob, 
+        FilterByFamiliesParameters, 
+        UserUploadedIdsParameters, 
+        FilenameParameters
+    ):
+    """
+    Inherits from the ESTGenerateJob class, adds parameters from various other
+    mixin classes. 
+    """
+    inputFasta: Mapped[str | None]
+    __mapper_args__ = {
+        "polymorphic_load": "selectin",
+        "polymorphic_identity": "est_generate_fasta"
+    }
+
+class ESTGenerateFamiliesJob(
+        Job, 
+        ProteinFamilyAdditionParameters,
+        ESTGenerateJob,
+        DomainBoundariesParameters,
+        ExcludeFragmentsParameters, 
+        FilterByTaxonomyParameters
+    ):
+    """
+    """
+    __mapper_args__ = {
+        "polymorphic_load": "selectin",
+        "polymorphic_identity": "est_generate_families"
+    }
+
+class ESTGenerateBlastJob(
+        Job, 
+        ProteinFamilyAdditionParameters,
+        ESTGenerateJob,
+        ExcludeFragmentsParameters, 
+        FilterByTaxonomyParameters,
+    ):
+    """
+    """
     blastQuery: Mapped[str | None]
     blastMaxSequences: Mapped[int | None]
-    blastDatabase: Mapped[str | None]   # str of uniprot, uniref50, uniref90. should it be an enum? 
-    blastEValue: Mapped[int | None]     # NOTE: should be a Double?
-   
-    # ESTGenerateFastaJob; fasta input path
-    inputFasta: Mapped[str | None]      # is this a file path or the actual full fasta file contents stored in the table?
+    blastDatabase: Mapped[str | None]        # NOTE: str of uniprot, uniref50, uniref90. should it be an enum? 
+    blastEValue: Mapped[int | None]         # NOTE: should be a double OR a string of the input floating point value to avoid number representation concerns
+    numBlastSeqRetr: Mapped[int | None]
+    # NOTE:
+    __mapper_args__ = {
+        "polymorphic_load": "selectin",
+        "polymorphic_identity": "est_generate_blast"
+    }
 
-    # ESTGenerateAccessionJob; accession IDs input path
-    accessionIds: Mapped[str | None]
+class ESTGenerateAccessionJob(
+        Job, 
+        ProteinFamilyAdditionParameters,
+        ESTGenerateJob,
+        DomainBoundariesParameters,
+        ExcludeFragmentsParameters, 
+        FilterByFamiliesParameters, 
+        FilterByTaxonomyParameters,
+        FilenameParameters,
+        UserUploadedIdsParameters, 
+    ):
+    """
+    """
+    accessionIds: Mapped[str | None] = mapped_column(
+        use_existing_column=True
+    )
     domainFamily: Mapped[str | None]
+    __mapper_args__ = {
+        "polymorphic_load": "selectin",
+        "polymorphic_identity": "est_generate_accession"
+    }
 
-    # ExcludeFragmentsTrait; fragment filtering parameters
-    excludeFragments: Mapped[int | None]    # NOTE: should this be a boolean?
+class ESTSSNFinalizationJob(
+        Job, 
+        ExcludeFragmentsParameters, 
+        FilterByTaxonomyParameters,
+    ):
+    """
+    """
+    alignmentScoreThreshold: Mapped[float | None]
+    minLength: Mapped[int | None] = mapped_column(
+        use_existing_column=True
+    )
+    maxLength: Mapped[int | None] = mapped_column(
+        use_existing_column=True
+    )
+    computeNeighborhoodConnectivity: Mapped[bool | None]
+    __mapper_args__ = {
+        "polymorphic_load": "selectin",
+        "polymorphic_identity": "est_ssn_finalization"
+    }
 
-    # ProteinFamilyAdditionTrait; adding families to whatever job; covers the families 
-    families: Mapped[str | None]
-    sequence_version: Mapped[str | None]    # NOTE: should this be an enum uniprot, uniref50, uniref90?
-    fraction: Mapped[int | None]    # NOTE: should this be a float? how is this handled on the backend?
+class ESTNeighborhoodConnectivityJob(Job, FilenameParameters):
+    """
+    """
+    __mapper_args__ = {
+        "polymorphic_load": "selectin",
+        "polymorphic_identity": "est_neighborhood_connectivity"
+    }
 
-    # FilterByTaxonomyTrait
-    taxSearch: Mapped[str | None]
-    taxSearchName: Mapped[str | None]
+class ESTConvergenceRatioJob(Job, FilenameParameters):
+    """
+    """
+    alignmentScore: Mapped[float | None]    # potentially redundant with alignmentScoreThreshold?
+    __mapper_args__ = {
+        "polymorphic_load": "selectin",
+        "polymorphic_identity": "est_convergence_ratio"
+    }
 
-    # DomainBoundariesTrait; domain filtering parameters
-    domain: Mapped[int | None]
-    domainRegion: Mapped[str | None]    # NOTE: should be an enum of "n-terminal", "c-terminal", "central", or "domain"
-
-    # FilterByFamiliesTrait; Families input path and filtering parameters
-    filterByFamilies: Mapped[str | None]
-    
-    # FilenameTrait; no idea what this is used for...
-    filename: Mapped[str | None] # NOTE: !!! very ambiguous column name...
-
-    # ESTClusterAnalysisJob; 
+class ESTClusterAnalysisJob(Job, FilenameParameters):
+    """
+    """
     minSeqMSA: Mapped[int | None]
     maxSeqMSA: Mapped[int | None]
+    __mapper_args__ = {
+        "polymorphic_load": "selectin",
+        "polymorphic_identity": "est_cluster_analysis"
+    }
 
-    # ESTConvergenceRatioJob; 
-    alignmentScore: Mapped[float | None]
+class ESTColorSSNJob(Job, FilenameParameters):
+    """
+    """
+    __mapper_args__ = {
+        "polymorphic_load": "selectin",
+        "polymorphic_identity": "est_color_ssn"
+    }
 
-    # ESTSSNFinalizationJob;
-    alignmentScoreThreshold: Mapped[float | None]
-    minLength: Mapped[int | None]
-    maxLength: Mapped[int | None]
-    computeNeighborhoodConnectivity: Mapped[int | None]     # NOTE: should this be a boolean?
-
-    # GNTGNNJob; 
+class GNTGNNJob(Job, FilenameParameters):
+    """
+    """
     cooccurrence: Mapped[float | None]
-    neighborhood_size: Mapped[int | None]
+    neighborhood_size: Mapped[int | None] = mapped_column(
+        use_existing_column=True
+    )
+    __mapper_args__ = {
+        "polymorphic_load": "selectin",
+        "polymorphic_identity": "gnt_gnn"
+    }
 
-    # GNTDiagramBlastJob; 
+class GNTDiagramSequenceIdJob(Job, GNTDiagramJob, SequenceDatabaseParameters):
+    """
+    """
+    accessionIds: Mapped[str | None] = mapped_column(
+        use_existing_column=True    # NOTE: reused from ESTGenerateAccessionJob
+    )
+    __mapper_args__ = {
+        "polymorphic_load": "selectin",
+        "polymorphic_identity": "gnt_diagram_sequence_id"
+    }
+
+class GNTDiagramFastaJob(Job, GNTDiagramJob):
+    """
+    """
+    fastaInput: Mapped[str | None] = mapped_column(
+        use_existing_column=True
+    )
+    __mapper_args__ = {
+        "polymorphic_load": "selectin",
+        "polymorphic_identity": "gnt_diagram_fasta"
+    }
+
+class GNTDiagramBlastJob(Job, GNTDiagramJob, SequenceDatabaseParameters):
+    """
+    """
     maxBlastSequences: Mapped[int | None]
-    blastSequence: Mapped[str | None]      # NOTE: is this really the sequence string or a file path where that sequence is written to
-    eValue: Mapped[int | None]     # NOTE: should be a Double?
+    blastSequence: Mapped[float | None]      # NOTE: is this really the sequence string or a file path where that sequence is written to
+    eValue: Mapped[int | None]     # NOTE: should be a Double? should be redundant with some other column?
+    __mapper_args__ = {
+        "polymorphic_load": "selectin",
+        "polymorphic_identity": "gnt_diagram_blast"
+    }
 
-    # GNTDiagramFastaJob; 
-    fastaInput: Mapped[str | None]
+class GNTViewDiagramJob(Job, FilenameParameters):
+    """
+    """
+    __mapper_args__ = {
+        "polymorphic_load": "selectin",
+        "polymorphic_identity": "gnt_view_diagram"
+    }
 
-    # GNTDiagramSequenceIdJob;
-    #accessionIds: Mapped[str | None] # NOTE: reused from ESTGenerateAccessionJob 
-
-    # CGFPIdentifyJob; 
+class CGFPIdentifyJob(Job, FilenameParameters):
+    """
+    """
     referenceDatabase: Mapped[str | None]
     cdhitSequenceIdentity: Mapped[int | None]      # NOTE: should be a double?
-    searchType: Mapped[str | None]
-    #minLength: Mapped[int | None]  # NOTE: reused from ESTSSNFinalizationJob
-    #maxLength: Mapped[int | None]  # NOTE: reused from ESTSSNFinalizationJob
+    searchType: Mapped[str | None] = mapped_column(
+        use_existing_column=True
+    )
+    minLength: Mapped[int | None] = mapped_column(
+        use_existing_column=True
+    )
+    maxLength: Mapped[int | None] = mapped_column(
+        use_existing_column=True
+    )
+    __mapper_args__ = {
+        "polymorphic_load": "selectin",
+        "polymorphic_identity": "cgfp_identify"
+    }
 
-    # CGFPQuantifyJob; 
-    metagenomes: Mapped[str | None]     # NOTE: what is this supposed to be used for? should it be a filepath
-    #searchType: Mapped[str | None]      # NOTE: reused for CGFPIdentifyJob
+class CGFPQuantifyJob(Job):
+    """
+    """
+    metagenomes: Mapped[str | None]
+    searchType: Mapped[str | None] = mapped_column(
+        use_existing_column=True
+    )
+    __mapper_args__ = {
+        "polymorphic_load": "selectin",
+        "polymorphic_identity": "cgfp_quantify"
+    }
 
-    # SequenceDatabaseTrait; 
-    sequenceDatabase: Mapped[str | None]
-    exclude_fragments: Mapped[int | None]   # redundant with the excludeFragments column?
+class TaxonomyAccessionJob(
+        Job,
+        ExcludeFragmentsParameters, 
+        FilterByFamiliesParameters, 
+        FilterByTaxonomyParameters,
+        FilenameParameters, 
+        SequenceDatabaseParameters
+    ):  
+    """
+    """
+    accessionIds: Mapped[str | None] = mapped_column(
+        use_existing_column=True    # NOTE: reused from ESTGenerateAccessionJob
+    )
+    __mapper_args__ = {
+        "polymorphic_load": "selectin",
+        "polymorphic_identity": "taxonomy_accession"
+    }
+
+class TaxonomyFamiliesJob(
+        Job,
+        ExcludeFragmentsParameters, 
+        FilterByFamiliesParameters, 
+        FilterByTaxonomyParameters,
+    ):
+    """
+    """
+    minLength: Mapped[int | None] = mapped_column(
+        use_existing_column=True
+    )
+    maxLength: Mapped[int | None] = mapped_column(
+        use_existing_column=True
+    )
+    __mapper_args__ = {
+        "polymorphic_load": "selectin",
+        "polymorphic_identity": "taxonomy_families"
+    }
+
+class TaxonomyFastaJob(
+        Job,
+        ExcludeFragmentsParameters, 
+        FilterByFamiliesParameters, 
+        FilterByTaxonomyParameters,
+        FilenameParameters
+    ):
+    """
+    """
+    fastaInput: Mapped[str | None] = mapped_column(
+        use_existing_column=True
+    )
+    __mapper_args__ = {
+        "polymorphic_load": "selectin",
+        "polymorphic_identity": "taxonomy_fasta"
+    }
+
+################################################################################
+
+"""
+QUESTIONS/STATEMENTS: 
+ ' id INT AUTO_INCREMENT NOT NULL",                     # moved to "job_id" attribute in 
+
+ ' user_id INT DEFAULT NULL',                           # why is this nullable?
+ " uuid CHAR(36) NOT NULL COMMENT '(DC2Type:guid)'",    # why is this not nullable but user_id is?
+ ' timeCreated DATETIME DEFAULT NULL',                  # why is this nullable? the fact the job is in the table means its been created?
+ ' efi_db_version VARCHAR(255) DEFAULT NULL',           # why is this nullable? 
+
+ ' inputFasta LONGTEXT DEFAULT NULL',                   # I don't think LONGTEXT should be here; theres no reason to allow users to input up to 4GB worth of fasta file into the job table. This needs to map to a file path whether they input their fasta file in the textbox or upload it. So users can put a huge string into the text box but it all gets written to file, whose path is input to this field 
+ ' blastSequence LONGTEXT DEFAULT NULL',
+ ' metagenomes LONGTEXT DEFAULT NULL',                  # I don't think LONGTEXT should be here; theres no reason to allow users to input up to 4GB worth of fasta file into the job table. This needs to map to a file path whether they input their fasta file in the textbox or upload it. So users can put a huge string into the text box but it all gets written to file, whose path is input to this field 
+
+ ' allByAllBlastEValue INT DEFAULT NULL',               # just fix the UI...
+ ' eValue INT DEFAULT NULL',        # just fix the UI...
+ ' fraction INT DEFAULT NULL',      # should this be an INT? just update the UI to make the value more clear
+ ' alignmentScore DOUBLE PRECISION DEFAULT NULL",       # stash doubles as strings instead? 
+ 
+ ' excludeFragments TINYINT(1) DEFAULT NULL',
+ ' exclude_fragments TINYINT(1) DEFAULT NULL',          # entity files SequenceDatabaseTrait.php and ExcludeFragmentsTrait.php both contain references to an excludeFragments column... is this redundant with that column? or are two instances of the column needed? 
+ 
+
+"""
+
+"""
+$this->addSql('CREATE TABLE Job (
+    
+    # Job
+    id INT AUTO_INCREMENT NOT NULL,
+    user_id INT DEFAULT NULL,
+    uuid CHAR(36) NOT NULL,
+    status VARCHAR(255) NOT NULL,
+	timeCreated DATETIME DEFAULT NULL,
+	timeStarted DATETIME DEFAULT NULL,
+	timeCompleted DATETIME DEFAULT NULL,
+	efi_db_version VARCHAR(255) DEFAULT NULL,
+	email VARCHAR(255) DEFAULT NULL,
+	isPublic TINYINT(1) NOT NULL,
+	isExample TINYINT(1) DEFAULT NULL,
+	parentJob_id INT DEFAULT NULL,
+	jobName VARCHAR(255) DEFAULT NULL,  # should not be here?
+	results JSON DEFAULT NULL,
+	job_type VARCHAR(255) NOT NULL,     # polymorph'd on
+	
+    # ProteinFamilyAdditionTrait
+	families TEXT DEFAULT NULL,
+	sequence_version VARCHAR(255) DEFAULT NULL,
+	fraction INT DEFAULT NULL,
+    numUnirefClusters INT DEFAULT NULL,
+    
+    # DomainBoundariesTrait
+	domain TINYINT(1) DEFAULT NULL,
+	domainRegion VARCHAR(255) DEFAULT NULL,
+
+    # ExcludeFragmentsTrait
+	excludeFragments TINYINT(1) DEFAULT NULL,
+
+    # FilterByTaxonomyTrait
+	taxSearch VARCHAR(255) DEFAULT NULL,
+	taxSearchName VARCHAR(255) DEFAULT NULL,
+
+    # FilterByFamiliesTrait
+	filterByFamilies VARCHAR(255) DEFAULT NULL,
+   
+    # UserUploadedIdsTrait
+	numMatchedIds INT DEFAULT NULL,
+	numUnmatchedIds INT DEFAULT NULL,
+
+    # FilenameTrait
+	uploadedFilename VARCHAR(255) DEFAULT NULL,
+
+    # SequenceDatabaseTrait
+	sequenceDatabase VARCHAR(255) DEFAULT NULL,
+	exclude_fragments TINYINT(1) DEFAULT NULL,  # redundant with excludeFragments
+
+    # ESTGenerateJob
+	allByAllBlastEValue INT DEFAULT NULL,
+    numFamilyOverlap INT DEFAULT NULL,
+	numNonFamily INT DEFAULT NULL,
+	numUnirefFamilyOverlap INT DEFAULT NULL,
+	numComputedSequences INT DEFAULT NULL,
+	numUniqueSequences INT DEFAULT NULL,
+	numBlastEdges INT DEFAULT NULL,
+
+    # ESTGenerateFastaJob
+	inputFasta LONGTEXT DEFAULT NULL,   !!!
+
+    # ESTGenerateBlastJob
+    blastQuery TEXT DEFAULT NULL,
+	blastMaxSequences INT DEFAULT NULL,
+	blastDatabase VARCHAR(255) DEFAULT NULL,
+	blastEValue INT DEFAULT NULL,
+	numBlastSeqRetr INT DEFAULT NULL,
+
+    # ESTGenerateAccessionJob
+	accessionIds VARCHAR(255) DEFAULT NULL,
+	domainFamily VARCHAR(255) DEFAULT NULL,
+
+    # ESTSSNFinalizationJob
+	alignmentScoreThreshold DOUBLE PRECISION DEFAULT NULL,
+	minLength INT DEFAULT NULL,
+	maxLength INT DEFAULT NULL,
+	computeNeighborhoodConnectivity TINYINT(1) DEFAULT NULL,
+
+    # ESTNeighborhoodConnectivityJob
+
+    # ESTConvergenceRatioJob
+    alignmentScore DOUBLE PRECISION DEFAULT NULL,   # potentially redundant with alignmentScoreThreshold?
+
+    # ESTClusterAnalysisJob
+	minSeqMSA INT DEFAULT NULL,
+	maxSeqMSA INT DEFAULT NULL,
+
+    # ESTColorSSNJob
+
+    # GNTGNNJob
+	cooccurrence DOUBLE PRECISION DEFAULT NULL,
+	neighborhood_size INT DEFAULT NULL,
+
+    # GNTDiagramJob
+
+    # GNTDiagramSequenceIdJob
+
+    # GNTDiagramFastaJob
+	fastaInput VARCHAR(255) DEFAULT NULL,   # shouldn't this be redundant with uploadedFilename?
+
+    # GNTDiagramBlastJob
+	maxBlastSequences INT DEFAULT NULL,
+	blastSequence LONGTEXT DEFAULT NULL,    # should not be LongText
+	eValue INT DEFAULT NULL,                # can this be made redundant with some other E-value column?
+
+    # GNTViewDiagramJob
+
+    # CGFPIdentifyJob
+	referenceDatabase VARCHAR(255) DEFAULT NULL,
+	cdhitSequenceIdentity INT DEFAULT NULL,
+	searchType VARCHAR(255) DEFAULT NULL,
+	minLength INT DEFAULT NULL,
+	maxLength INT DEFAULT NULL,
+
+    # CGFPQuantifyJob
+	metagenomes LONGTEXT DEFAULT NULL,  # !!!
+	searchType VARCHAR(255) DEFAULT NULL,
 
 
-    def __repr__(self):
-        if self.status in Status.COMPLETED:
-            completed_string = f"timeStarted='{self.timeStarted}', timeCompleted='{self.timeCompleted}'"
-        elif self.status == Status.RUNNING:
-            completed_string = f"timeStarted='{self.timeStarted}'"
-        else:
-            completed_string = ""
-        return (f"<Job(id={self.job_id}," 
-                + f" status='{self.status}'," 
-                + f" efi_type='{self.efi_type}'," 
-                + f" timeCreated='{self.timeCreated}'" 
-                + f" {completed_string})>")
+
+	INDEX IDX_C395A618A76ED395 (user_id),
+	INDEX IDX_C395A6184A4533A0 (parentJob_id),
+	PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+$this->addSql('ALTER TABLE Job ADD CONSTRAINT FK_C395A618A76ED395 FOREIGN KEY (user_id) REFERENCES users (id)');
+$this->addSql('ALTER TABLE Job ADD CONSTRAINT FK_C395A6184A4533A0 FOREIGN KEY (parentJob_id) REFERENCES Job (id)');
+
+"""
+
+
+
+
+
+
+
+
 

--- a/job_exec/jobModels/job_efi_web_orm.py
+++ b/job_exec/jobModels/job_efi_web_orm.py
@@ -1,0 +1,184 @@
+
+from datetime import datetime
+
+import sqlalchemy
+
+from sqlalchemy import String, DateTime, func
+from sqlalchemy.orm import DeclarativeBase, mapped_column, Mapped
+from sqlalchemy.types import TypeDecorator
+
+from constants import Status
+
+class FlagEnumType(TypeDecorator):
+    """ 
+    SQLAlchemy does not know how to handle python Enum/Flag values as DB column
+    values. This class is developing the custom handling of a String column 
+    (stored as a VARCHAR or equivalent) and an associated python Flag object.
+
+    This is general code that works for any python Flag Enum, but is intended 
+    for the Status object and the status column in the DB. 
+    """
+    impl = String   # DB column is implemented as a SQLAlchemy String 
+    cache_ok = True
+
+    def __init__(self, enum_class, *args, **kwargs):
+        self.enum_class = enum_class
+        super().__init__(*args, **kwargs)
+
+    def process_bind_param(self, value: Status, dialect):
+        """ 
+        Overwrite TypeDecorator.process_bind_param() method to implement custom
+        handling for this object. Documentation:
+        https://docs.sqlalchemy.org/en/20/core/custom_types.html#sqlalchemy.types.TypeDecorator.process_bind_param
+
+        This is used to convert an instance of the python Flag class (e.g. 
+        Status.QUEUED) into a string that can be used in the SQL DB (e.g. 
+        "queued"). 
+        """
+        return value.__str__()
+
+    def process_result_value(self, value, dialect):
+        """
+        Overwrite TypeDecorator.process_result_value() method to implement 
+        custom handling for this object. Documentation:
+        https://docs.sqlalchemy.org/en/20/core/custom_types.html#sqlalchemy.types.TypeDecorator.process_result_value
+
+        This is used to convert a result-row column's value to the returned 
+        python type, in this case a Flag object (e.g. "queued" in the DB is 
+        converted to Status.QUEUED)
+        """
+        if value is None:
+            return None
+        return self.enum_class.getStatus(value)
+
+class Base(DeclarativeBase):
+    ## can do a whole bunch of stuff in this class before passing it on to 
+    ## inhereting class/tables like explicitly control python types and their 
+    ## associated sqlalchemy types
+    #type_annotation_map = {}
+    pass
+
+class Job(Base):
+    """
+    SQLAlchemy model for the EFI-Web 'Job' table. 
+    """
+    __tablename__ = 'Job'
+
+    # SQLalchemy ORM 2.0x notes: PEP484 type annotations used with `Mapped`
+    # enables skipping the `mapped_column()` call. The `Mapped` annotation can
+    # be used to set datatype _and_ nullability for the column. Default for 
+    # nullable is True for non-primary key columns.
+    job_id: Mapped[int] = mapped_column("id", primary_key=True)
+    uuid: Mapped[str] = mapped_column(nullable=False)
+    user: Mapped[int] = mapped_column("user_id")    # , nullable=False
+    status: Mapped[Status] = mapped_column(FlagEnumType(Status), nullable=False)
+    timeCreated: Mapped[datetime | None] = mapped_column(
+        server_default=func.now()   # NOTE: do I need this???
+    )
+    timeStarted: Mapped[datetime | None]
+    timeCompleted: Mapped[datetime | None]
+    efi_db_version: Mapped[str | None]
+    email: Mapped[str | None]
+    isPublic: Mapped[int] = mapped_column(nullable=False)   # NOTE: Should be boolean?
+    parentJob_id: Mapped[int | None]
+    job_type: Mapped[str] = mapped_column(nullable=False)   # NOTE: change this to an enum
+    
+    results: Mapped[str | None] # NOTE: gonna change?
+   
+    ### input parameter columns
+    # ESTGenerateJob; EST-general parameters
+    allByAllBlastEValue: Mapped[int | None]    # NOTE: should be a double
+    jobName: Mapped[str | None]     # NOTE: why is this specific to EST? Shouldn't GNT also have a jobName column?
+
+    # ESTGenerateBlastJob; blast input path
+    blastQuery: Mapped[str | None]
+    blastMaxSequences: Mapped[int | None]
+    blastDatabase: Mapped[str | None]   # str of uniprot, uniref50, uniref90. should it be an enum? 
+    blastEValue: Mapped[int | None]     # NOTE: should be a Double?
+   
+    # ESTGenerateFastaJob; fasta input path
+    inputFasta: Mapped[str | None]      # is this a file path or the actual full fasta file contents stored in the table?
+
+    # ESTGenerateAccessionJob; accession IDs input path
+    accessionIds: Mapped[str | None]
+    domainFamily: Mapped[str | None]
+
+    # ExcludeFragmentsTrait; fragment filtering parameters
+    excludeFragments: Mapped[int | None]    # NOTE: should this be a boolean?
+
+    # ProteinFamilyAdditionTrait; adding families to whatever job; covers the families 
+    families: Mapped[str | None]
+    sequence_version: Mapped[str | None]    # NOTE: should this be an enum uniprot, uniref50, uniref90?
+    fraction: Mapped[int | None]    # NOTE: should this be a float? how is this handled on the backend?
+
+    # FilterByTaxonomyTrait
+    taxSearch: Mapped[str | None]
+    taxSearchName: Mapped[str | None]
+
+    # DomainBoundariesTrait; domain filtering parameters
+    domain: Mapped[int | None]
+    domainRegion: Mapped[str | None]    # NOTE: should be an enum of "n-terminal", "c-terminal", "central", or "domain"
+
+    # FilterByFamiliesTrait; Families input path and filtering parameters
+    filterByFamilies: Mapped[str | None]
+    
+    # FilenameTrait; no idea what this is used for...
+    filename: Mapped[str | None] # NOTE: !!! very ambiguous column name...
+
+    # ESTClusterAnalysisJob; 
+    minSeqMSA: Mapped[int | None]
+    maxSeqMSA: Mapped[int | None]
+
+    # ESTConvergenceRatioJob; 
+    alignmentScore: Mapped[float | None]
+
+    # ESTSSNFinalizationJob;
+    alignmentScoreThreshold: Mapped[float | None]
+    minLength: Mapped[int | None]
+    maxLength: Mapped[int | None]
+    computeNeighborhoodConnectivity: Mapped[int | None]     # NOTE: should this be a boolean?
+
+    # GNTGNNJob; 
+    cooccurrence: Mapped[float | None]
+    neighborhood_size: Mapped[int | None]
+
+    # GNTDiagramBlastJob; 
+    maxBlastSequences: Mapped[int | None]
+    blastSequence: Mapped[str | None]      # NOTE: is this really the sequence string or a file path where that sequence is written to
+    eValue: Mapped[int | None]     # NOTE: should be a Double?
+
+    # GNTDiagramFastaJob; 
+    fastaInput: Mapped[str | None]
+
+    # GNTDiagramSequenceIdJob;
+    #accessionIds: Mapped[str | None] # NOTE: reused from ESTGenerateAccessionJob 
+
+    # CGFPIdentifyJob; 
+    referenceDatabase: Mapped[str | None]
+    cdhitSequenceIdentity: Mapped[int | None]      # NOTE: should be a double?
+    searchType: Mapped[str | None]
+    #minLength: Mapped[int | None]  # NOTE: reused from ESTSSNFinalizationJob
+    #maxLength: Mapped[int | None]  # NOTE: reused from ESTSSNFinalizationJob
+
+    # CGFPQuantifyJob; 
+    metagenomes: Mapped[str | None]     # NOTE: what is this supposed to be used for? should it be a filepath
+    #searchType: Mapped[str | None]      # NOTE: reused for CGFPIdentifyJob
+
+    # SequenceDatabaseTrait; 
+    sequenceDatabase: Mapped[str | None]
+    exclude_fragments: Mapped[int | None]   # redundant with the excludeFragments column?
+
+
+    def __repr__(self):
+        if self.status in Status.COMPLETED:
+            completed_string = f"timeStarted='{self.timeStarted}', timeCompleted='{self.timeCompleted}'"
+        elif self.status == Status.RUNNING:
+            completed_string = f"timeStarted='{self.timeStarted}'"
+        else:
+            completed_string = ""
+        return (f"<Job(id={self.job_id}," 
+                + f" status='{self.status}'," 
+                + f" efi_type='{self.efi_type}'," 
+                + f" timeCreated='{self.timeCreated}'" 
+                + f" {completed_string})>")
+

--- a/job_exec/jobModels/job_efi_web_orm.py
+++ b/job_exec/jobModels/job_efi_web_orm.py
@@ -1,16 +1,15 @@
 
 from datetime import datetime
-from enum import Enum
+from enum import Flag
 
 import sqlalchemy
 
-from sqlalchemy import func
+from sqlalchemy import String, func
 from sqlalchemy.orm import DeclarativeBase, mapped_column, Mapped
 from sqlalchemy.types import TypeDecorator
 
 from constants import Status
 
-# NOTE: generalize this to non-Status enums too
 class FlagEnumType(TypeDecorator):
     """ 
     SQLAlchemy does not know how to handle python Enum/Flag values as DB column
@@ -20,15 +19,14 @@ class FlagEnumType(TypeDecorator):
     This is general code that works for any python Flag Enum, but is intended 
     for the Status object and the status column in the DB. 
     """
-    impl = str   # DB column is implemented as a SQLAlchemy str 
+    impl = String   # DB column is implemented as a SQLAlchemy String
     cache_ok = True
 
     def __init__(self, enum_class, *args, **kwargs):
         self.enum_class = enum_class
         super().__init__(*args, **kwargs)
 
-    # NOTE: generalize this to non-Status enums too
-    def process_bind_param(self, value, dialect):
+    def process_bind_param(self, value: Flag, dialect):
         """ 
         Overwrite TypeDecorator.process_bind_param() method to implement custom
         handling for this object. Documentation:
@@ -40,7 +38,7 @@ class FlagEnumType(TypeDecorator):
         """
         return value.__str__()
 
-    def process_result_value(self, value, dialect):
+    def process_result_value(self, value, dialect) -> Flag:
         """
         Overwrite TypeDecorator.process_result_value() method to implement 
         custom handling for this object. Documentation:
@@ -50,8 +48,6 @@ class FlagEnumType(TypeDecorator):
         python type, for example a status column value of "queued" in the DB is 
         converted to Status.QUEUED.
         """
-        if value is None:
-            return None
         return self.enum_class.getFlag(value)
 
 class Base(DeclarativeBase):
@@ -82,37 +78,58 @@ class Job(Base):
     isPublic: Mapped[bool] = mapped_column(nullable=False)
     isExample: Mapped[bool | None]   # should this be nullable?
     parentJob_id: Mapped[int | None]
-    # placeholder columns
-    jobName: Mapped[str | None]      # in symfony, this is associated with ESTGenerateJob
-    results: Mapped[str | None] # NOTE: gonna change
-   
+    schedulerJobId: Mapped[int | None]
+    jobName: Mapped[str | None]
+    results: Mapped[str | None] # NOTE: gonna change?
     job_type: Mapped[str] = mapped_column(nullable=False) # used as the polymorphic_on attribute
     __mapper_args__ = {
         "polymorphic_on": "job_type",
         "polymorphic_identity": "job",
     }
 
-    #def __repr__(self):
-    #    if self.status in Status.COMPLETED:
-    #        completed_string = f"timeStarted='{self.timeStarted}', timeCompleted='{self.timeCompleted}'"
-    #    elif self.status == Status.RUNNING:
-    #        completed_string = f"timeStarted='{self.timeStarted}'"
-    #    else:
-    #        completed_string = ""
-    #    return (f"<self.__class__.__name__(id={self.job_id}," 
-    #            + f" status='{self.status}'," 
-    #            + f" efi_type='{self.efi_type}'," 
-    #            + f" timeCreated='{self.timeCreated}'" 
-    #            + f" {completed_string})>")
+    def __repr__(self):
+        if self.status in Status.COMPLETED:
+            completed_string = f"timeStarted='{self.timeStarted}', timeCompleted='{self.timeCompleted}'"
+        elif self.status == Status.RUNNING:
+            completed_string = f"timeStarted='{self.timeStarted}'"
+        else:
+            completed_string = ""
+        return (f"<self.__class__.__name__(id={self.job_id}," 
+                + f" status='{self.status}'," 
+                + f" efi_type='{self.efi_type}'," 
+                + f" timeCreated='{self.timeCreated}'" 
+                + f" {completed_string})>")
 
 ################################################################################
 # Mixin Column Classes
+
+# columns shared across multiple mixin classes:
+# - neighborhoodSize and neighborhoodWindowSize
+
+class AlignmentScoreParameters:
+    alignmentScore: Mapped[int | None] = mapped_column(
+        use_existing_column=True
+    )
+
+class BlastSequenceParameters:
+    blastSequence: Mapped[str | None] = mapped_column(
+        use_existing_column=True
+    )
+
+# temp name for this. match to the Trait.php file on efi-web (assuming its made)
+class SequenceLengthParameters:
+    minLength: Mapped[int | None] = mapped_column(
+        use_existing_column=True
+    )
+    maxLength: Mapped[int | None] = mapped_column(
+        use_existing_column=True
+    )
 
 class ProteinFamilyAdditionParameters:
     families: Mapped[str | None] = mapped_column(
         use_existing_column=True
     )
-    sequence_version: Mapped[str | None] = mapped_column(    # NOTE: should this be an enum uniprot, uniref50, uniref90? Is this redundant with blastDatabase?
+    sequence_version: Mapped[str | None] = mapped_column(
         use_existing_column=True
     )
     fraction: Mapped[int | None] = mapped_column(    # NOTE: should this be a float? how is this handled on the backend?
@@ -126,7 +143,7 @@ class DomainBoundariesParameters:
     domain: Mapped[bool | None] = mapped_column(
         use_existing_column=True
     )
-    domainRegion: Mapped[str | None] = mapped_column(         # NOTE: should be an enum of "n-terminal", "c-terminal", "central", or "domain"?
+    domainRegion: Mapped[str | None] = mapped_column(
         use_existing_column=True
     )
 
@@ -160,24 +177,34 @@ class FilenameParameters:
     uploadedFilename: Mapped[str | None] = mapped_column(
         use_existing_column=True
     )
+    jobFilename: Mapped[str | None] = mapped_column(
+        use_existing_column=True
+    )
+    updatedAt: Mapped[datetime | None] = mapped_column(
+        use_existing_column=True
+    )
 
 class SequenceDatabaseParameters:
+    blastEValue: Mapped[int | None] = mapped_column(
+        use_existing_column=True
+    )
+    maxBlastSequences: Mapped[int | None] = mapped_column(
+        use_existing_column=True
+    )
     sequenceDatabase: Mapped[str | None] = mapped_column(
         use_existing_column=True
     )
-    exclude_fragments: Mapped[bool | None] = mapped_column(
+
+class SearchParameters:
+    searchType: Mapped[str | None] = mapped_column(
         use_existing_column=True
     )
 
-#class ESTGenerateJob(Job, ProteinFamilyAdditionParameters):
 class ESTGenerateJob:
-    """
-    Inherits from Job class, adds ProteinFamilyAdditionParameters since any 
-    EST input path can use those fields. Does not get polymorph'd on.
-    """
     allByAllBlastEValue: Mapped[int | None] = mapped_column(
         use_existing_column=True
     )
+    # results columns
     numFamilyOverlap: Mapped[int | None] = mapped_column( 
         use_existing_column=True
     )
@@ -196,35 +223,11 @@ class ESTGenerateJob:
     numBlastEdges: Mapped[int | None] = mapped_column( 
         use_existing_column=True
     )
-    
-    #__mapper_args__ = {
-    #    'polymorphic_abstract=True'
-    #}
 
-#class GNTDiagramJob(Job):
 class GNTDiagramJob:
-    """
-    Inherits from Job class, used as parent class to GNTDiagramBlast, 
-    GNTDiagramFasta, and GNTDiagramSequenceId. Does not get polymorph'd on.
-    """
-    neighborhood_size: Mapped[int | None] = mapped_column(
+    neighborhoodWindowSize: Mapped[int | None] = mapped_column(
         use_existing_column=True
     )
-    #__mapper_args__ = {
-    #    'polymorphic_abstract=True'
-    #}
-
-#class TaxonomyJob(
-#        Job,
-#        ExcludeFragmentsParameters, 
-#        FilterByFamiliesParameters, 
-#        FilterByTaxonomyParameters,
-#    ):
-#    """
-#    """
-#    __mapper_args__ = {
-#        'polymorphic_abstract=True'
-#    }
 
 ###############################################################################
 # polymorphic_identity classes
@@ -249,7 +252,7 @@ class ESTGenerateFastaJob(
 
 class ESTGenerateFamiliesJob(
         Job, 
-        ProteinFamilyAdditionParameters,
+     sed to compute the GNNs themselves.  The window size is for how many neighbors to retrieve for GNDs.   ProteinFamilyAdditionParameters,
         ESTGenerateJob,
         DomainBoundariesParameters,
         ExcludeFragmentsParameters, 
@@ -264,19 +267,15 @@ class ESTGenerateFamiliesJob(
 
 class ESTGenerateBlastJob(
         Job, 
-        ProteinFamilyAdditionParameters,
         ESTGenerateJob,
+        BlastSequenceParameters,
         ExcludeFragmentsParameters, 
         FilterByTaxonomyParameters,
+        ProteinFamilyAdditionParameters,
+        SequenceDatabaseParameters,
     ):
     """
     """
-    blastQuery: Mapped[str | None]
-    blastMaxSequences: Mapped[int | None]
-    blastDatabase: Mapped[str | None]        # NOTE: str of uniprot, uniref50, uniref90. should it be an enum? 
-    blastEValue: Mapped[int | None]         # NOTE: should be a double OR a string of the input floating point value to avoid number representation concerns
-    numBlastSeqRetr: Mapped[int | None]
-    # NOTE:
     __mapper_args__ = {
         "polymorphic_load": "selectin",
         "polymorphic_identity": "est_generate_blast"
@@ -284,20 +283,17 @@ class ESTGenerateBlastJob(
 
 class ESTGenerateAccessionJob(
         Job, 
-        ProteinFamilyAdditionParameters,
         ESTGenerateJob,
         DomainBoundariesParameters,
         ExcludeFragmentsParameters, 
+        FilenameParameters,
         FilterByFamiliesParameters, 
         FilterByTaxonomyParameters,
-        FilenameParameters,
         UserUploadedIdsParameters, 
+        ProteinFamilyAdditionParameters,
     ):
     """
     """
-    accessionIds: Mapped[str | None] = mapped_column(
-        use_existing_column=True
-    )
     domainFamily: Mapped[str | None]
     __mapper_args__ = {
         "polymorphic_load": "selectin",
@@ -306,18 +302,13 @@ class ESTGenerateAccessionJob(
 
 class ESTSSNFinalizationJob(
         Job, 
+        AligmentScoreParameters,
         ExcludeFragmentsParameters, 
         FilterByTaxonomyParameters,
+        SequenceLengthParameters,
     ):
     """
     """
-    alignmentScoreThreshold: Mapped[float | None]
-    minLength: Mapped[int | None] = mapped_column(
-        use_existing_column=True
-    )
-    maxLength: Mapped[int | None] = mapped_column(
-        use_existing_column=True
-    )
     computeNeighborhoodConnectivity: Mapped[bool | None]
     __mapper_args__ = {
         "polymorphic_load": "selectin",
@@ -332,10 +323,13 @@ class ESTNeighborhoodConnectivityJob(Job, FilenameParameters):
         "polymorphic_identity": "est_neighborhood_connectivity"
     }
 
-class ESTConvergenceRatioJob(Job, FilenameParameters):
+class ESTConvergenceRatioJob(
+        Job, 
+        AlignmentScoreParameters, 
+        FilenameParameters
+    ):
     """
     """
-    alignmentScore: Mapped[float | None]    # potentially redundant with alignmentScoreThreshold?
     __mapper_args__ = {
         "polymorphic_load": "selectin",
         "polymorphic_identity": "est_convergence_ratio"
@@ -359,49 +353,52 @@ class ESTColorSSNJob(Job, FilenameParameters):
         "polymorphic_identity": "est_color_ssn"
     }
 
-class GNTGNNJob(Job, FilenameParameters):
+class GNTGNNJob(Job, GNTDiagramJob, FilenameParameters):
     """
     """
     cooccurrence: Mapped[float | None]
-    neighborhood_size: Mapped[int | None] = mapped_column(
-        use_existing_column=True
-    )
+    neighborhood_size: Mapped[int | None]   # = mapped_column(
+    #    use_existing_column=True
+    #)
     __mapper_args__ = {
         "polymorphic_load": "selectin",
         "polymorphic_identity": "gnt_gnn"
     }
 
-class GNTDiagramSequenceIdJob(Job, GNTDiagramJob, SequenceDatabaseParameters):
+class GNTDiagramBlastJob(
+        Job, 
+        GNTDiagramJob,
+        BlastSequenceParameters,
+        ExcludeFragmentsParameters,
+        SequenceDatabaseParameters,
+    ):
     """
     """
-    accessionIds: Mapped[str | None] = mapped_column(
-        use_existing_column=True    # NOTE: reused from ESTGenerateAccessionJob
-    )
     __mapper_args__ = {
         "polymorphic_load": "selectin",
-        "polymorphic_identity": "gnt_diagram_sequence_id"
+        "polymorphic_identity": "gnt_diagram_blast"
     }
 
-class GNTDiagramFastaJob(Job, GNTDiagramJob):
+class GNTDiagramFastaJob(Job, GNTDiagramJob, FilenameParameters):
     """
     """
-    fastaInput: Mapped[str | None] = mapped_column(
-        use_existing_column=True
-    )
     __mapper_args__ = {
         "polymorphic_load": "selectin",
         "polymorphic_identity": "gnt_diagram_fasta"
     }
 
-class GNTDiagramBlastJob(Job, GNTDiagramJob, SequenceDatabaseParameters):
+class GNTDiagramSequenceIdJob(
+        Job, 
+        GNTDiagramJob,
+        ExcludeFragmentsParameters,
+        FilenameParameters,
+        SequenceDatabaseParameters
+    ):
     """
     """
-    maxBlastSequences: Mapped[int | None]
-    blastSequence: Mapped[float | None]      # NOTE: is this really the sequence string or a file path where that sequence is written to
-    eValue: Mapped[int | None]     # NOTE: should be a Double? should be redundant with some other column?
     __mapper_args__ = {
         "polymorphic_load": "selectin",
-        "polymorphic_identity": "gnt_diagram_blast"
+        "polymorphic_identity": "gnt_diagram_sequence_id"
     }
 
 class GNTViewDiagramJob(Job, FilenameParameters):
@@ -412,32 +409,26 @@ class GNTViewDiagramJob(Job, FilenameParameters):
         "polymorphic_identity": "gnt_view_diagram"
     }
 
-class CGFPIdentifyJob(Job, FilenameParameters):
+class CGFPIdentifyJob(
+        Job, 
+        FilenameParameters,
+        SearchParmeters,
+        SequenceLengthParameters,
+    ):
     """
     """
     referenceDatabase: Mapped[str | None]
     cdhitSequenceIdentity: Mapped[int | None]      # NOTE: should be a double?
-    searchType: Mapped[str | None] = mapped_column(
-        use_existing_column=True
-    )
-    minLength: Mapped[int | None] = mapped_column(
-        use_existing_column=True
-    )
-    maxLength: Mapped[int | None] = mapped_column(
-        use_existing_column=True
-    )
     __mapper_args__ = {
         "polymorphic_load": "selectin",
         "polymorphic_identity": "cgfp_identify"
     }
 
-class CGFPQuantifyJob(Job):
+class CGFPQuantifyJob(Job,SearchParmeters):
+        
     """
     """
     metagenomes: Mapped[str | None]
-    searchType: Mapped[str | None] = mapped_column(
-        use_existing_column=True
-    )
     __mapper_args__ = {
         "polymorphic_load": "selectin",
         "polymorphic_identity": "cgfp_quantify"
@@ -453,9 +444,6 @@ class TaxonomyAccessionJob(
     ):  
     """
     """
-    accessionIds: Mapped[str | None] = mapped_column(
-        use_existing_column=True    # NOTE: reused from ESTGenerateAccessionJob
-    )
     __mapper_args__ = {
         "polymorphic_load": "selectin",
         "polymorphic_identity": "taxonomy_accession"
@@ -466,15 +454,10 @@ class TaxonomyFamiliesJob(
         ExcludeFragmentsParameters, 
         FilterByFamiliesParameters, 
         FilterByTaxonomyParameters,
+        SequenceLengthParameters,
     ):
     """
     """
-    minLength: Mapped[int | None] = mapped_column(
-        use_existing_column=True
-    )
-    maxLength: Mapped[int | None] = mapped_column(
-        use_existing_column=True
-    )
     __mapper_args__ = {
         "polymorphic_load": "selectin",
         "polymorphic_identity": "taxonomy_families"
@@ -489,175 +472,10 @@ class TaxonomyFastaJob(
     ):
     """
     """
-    fastaInput: Mapped[str | None] = mapped_column(
-        use_existing_column=True
-    )
     __mapper_args__ = {
         "polymorphic_load": "selectin",
         "polymorphic_identity": "taxonomy_fasta"
     }
 
 ################################################################################
-
-"""
-QUESTIONS/STATEMENTS: 
- ' id INT AUTO_INCREMENT NOT NULL",                     # moved to "job_id" attribute in 
-
- ' user_id INT DEFAULT NULL',                           # why is this nullable?
- " uuid CHAR(36) NOT NULL COMMENT '(DC2Type:guid)'",    # why is this not nullable but user_id is?
- ' timeCreated DATETIME DEFAULT NULL',                  # why is this nullable? the fact the job is in the table means its been created?
- ' efi_db_version VARCHAR(255) DEFAULT NULL',           # why is this nullable? 
-
- ' inputFasta LONGTEXT DEFAULT NULL',                   # I don't think LONGTEXT should be here; theres no reason to allow users to input up to 4GB worth of fasta file into the job table. This needs to map to a file path whether they input their fasta file in the textbox or upload it. So users can put a huge string into the text box but it all gets written to file, whose path is input to this field 
- ' blastSequence LONGTEXT DEFAULT NULL',
- ' metagenomes LONGTEXT DEFAULT NULL',                  # I don't think LONGTEXT should be here; theres no reason to allow users to input up to 4GB worth of fasta file into the job table. This needs to map to a file path whether they input their fasta file in the textbox or upload it. So users can put a huge string into the text box but it all gets written to file, whose path is input to this field 
-
- ' allByAllBlastEValue INT DEFAULT NULL',               # just fix the UI...
- ' eValue INT DEFAULT NULL',        # just fix the UI...
- ' fraction INT DEFAULT NULL',      # should this be an INT? just update the UI to make the value more clear
- ' alignmentScore DOUBLE PRECISION DEFAULT NULL",       # stash doubles as strings instead? 
- 
- ' excludeFragments TINYINT(1) DEFAULT NULL',
- ' exclude_fragments TINYINT(1) DEFAULT NULL',          # entity files SequenceDatabaseTrait.php and ExcludeFragmentsTrait.php both contain references to an excludeFragments column... is this redundant with that column? or are two instances of the column needed? 
- 
-
-"""
-
-"""
-$this->addSql('CREATE TABLE Job (
-    
-    # Job
-    id INT AUTO_INCREMENT NOT NULL,
-    user_id INT DEFAULT NULL,
-    uuid CHAR(36) NOT NULL,
-    status VARCHAR(255) NOT NULL,
-	timeCreated DATETIME DEFAULT NULL,
-	timeStarted DATETIME DEFAULT NULL,
-	timeCompleted DATETIME DEFAULT NULL,
-	efi_db_version VARCHAR(255) DEFAULT NULL,
-	email VARCHAR(255) DEFAULT NULL,
-	isPublic TINYINT(1) NOT NULL,
-	isExample TINYINT(1) DEFAULT NULL,
-	parentJob_id INT DEFAULT NULL,
-	jobName VARCHAR(255) DEFAULT NULL,  # should not be here?
-	results JSON DEFAULT NULL,
-	job_type VARCHAR(255) NOT NULL,     # polymorph'd on
-	
-    # ProteinFamilyAdditionTrait
-	families TEXT DEFAULT NULL,
-	sequence_version VARCHAR(255) DEFAULT NULL,
-	fraction INT DEFAULT NULL,
-    numUnirefClusters INT DEFAULT NULL,
-    
-    # DomainBoundariesTrait
-	domain TINYINT(1) DEFAULT NULL,
-	domainRegion VARCHAR(255) DEFAULT NULL,
-
-    # ExcludeFragmentsTrait
-	excludeFragments TINYINT(1) DEFAULT NULL,
-
-    # FilterByTaxonomyTrait
-	taxSearch VARCHAR(255) DEFAULT NULL,
-	taxSearchName VARCHAR(255) DEFAULT NULL,
-
-    # FilterByFamiliesTrait
-	filterByFamilies VARCHAR(255) DEFAULT NULL,
-   
-    # UserUploadedIdsTrait
-	numMatchedIds INT DEFAULT NULL,
-	numUnmatchedIds INT DEFAULT NULL,
-
-    # FilenameTrait
-	uploadedFilename VARCHAR(255) DEFAULT NULL,
-
-    # SequenceDatabaseTrait
-	sequenceDatabase VARCHAR(255) DEFAULT NULL,
-	exclude_fragments TINYINT(1) DEFAULT NULL,  # redundant with excludeFragments
-
-    # ESTGenerateJob
-	allByAllBlastEValue INT DEFAULT NULL,
-    numFamilyOverlap INT DEFAULT NULL,
-	numNonFamily INT DEFAULT NULL,
-	numUnirefFamilyOverlap INT DEFAULT NULL,
-	numComputedSequences INT DEFAULT NULL,
-	numUniqueSequences INT DEFAULT NULL,
-	numBlastEdges INT DEFAULT NULL,
-
-    # ESTGenerateFastaJob
-	inputFasta LONGTEXT DEFAULT NULL,   !!!
-
-    # ESTGenerateBlastJob
-    blastQuery TEXT DEFAULT NULL,
-	blastMaxSequences INT DEFAULT NULL,
-	blastDatabase VARCHAR(255) DEFAULT NULL,
-	blastEValue INT DEFAULT NULL,
-	numBlastSeqRetr INT DEFAULT NULL,
-
-    # ESTGenerateAccessionJob
-	accessionIds VARCHAR(255) DEFAULT NULL,
-	domainFamily VARCHAR(255) DEFAULT NULL,
-
-    # ESTSSNFinalizationJob
-	alignmentScoreThreshold DOUBLE PRECISION DEFAULT NULL,
-	minLength INT DEFAULT NULL,
-	maxLength INT DEFAULT NULL,
-	computeNeighborhoodConnectivity TINYINT(1) DEFAULT NULL,
-
-    # ESTNeighborhoodConnectivityJob
-
-    # ESTConvergenceRatioJob
-    alignmentScore DOUBLE PRECISION DEFAULT NULL,   # potentially redundant with alignmentScoreThreshold?
-
-    # ESTClusterAnalysisJob
-	minSeqMSA INT DEFAULT NULL,
-	maxSeqMSA INT DEFAULT NULL,
-
-    # ESTColorSSNJob
-
-    # GNTGNNJob
-	cooccurrence DOUBLE PRECISION DEFAULT NULL,
-	neighborhood_size INT DEFAULT NULL,
-
-    # GNTDiagramJob
-
-    # GNTDiagramSequenceIdJob
-
-    # GNTDiagramFastaJob
-	fastaInput VARCHAR(255) DEFAULT NULL,   # shouldn't this be redundant with uploadedFilename?
-
-    # GNTDiagramBlastJob
-	maxBlastSequences INT DEFAULT NULL,
-	blastSequence LONGTEXT DEFAULT NULL,    # should not be LongText
-	eValue INT DEFAULT NULL,                # can this be made redundant with some other E-value column?
-
-    # GNTViewDiagramJob
-
-    # CGFPIdentifyJob
-	referenceDatabase VARCHAR(255) DEFAULT NULL,
-	cdhitSequenceIdentity INT DEFAULT NULL,
-	searchType VARCHAR(255) DEFAULT NULL,
-	minLength INT DEFAULT NULL,
-	maxLength INT DEFAULT NULL,
-
-    # CGFPQuantifyJob
-	metagenomes LONGTEXT DEFAULT NULL,  # !!!
-	searchType VARCHAR(255) DEFAULT NULL,
-
-
-
-	INDEX IDX_C395A618A76ED395 (user_id),
-	INDEX IDX_C395A6184A4533A0 (parentJob_id),
-	PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
-$this->addSql('ALTER TABLE Job ADD CONSTRAINT FK_C395A618A76ED395 FOREIGN KEY (user_id) REFERENCES users (id)');
-$this->addSql('ALTER TABLE Job ADD CONSTRAINT FK_C395A6184A4533A0 FOREIGN KEY (parentJob_id) REFERENCES Job (id)');
-
-"""
-
-
-
-
-
-
-
-
 

--- a/job_exec/jobModels/job_efi_web_orm.py
+++ b/job_exec/jobModels/job_efi_web_orm.py
@@ -1,6 +1,7 @@
 
 from datetime import datetime
 from enum import Flag
+import json
 
 import sqlalchemy
 
@@ -99,6 +100,14 @@ class Job(Base):
                 + f" efi_type='{self.efi_type}'," 
                 + f" timeCreated='{self.timeCreated}'" 
                 + f" {completed_string})>")
+
+    def generate_params_str(self) -> str:
+        """
+        Create a yaml-formatted string containing the key:value pairs for the 
+        given row
+        """
+        #subdict = {}
+        return json.dumps(self.__dict__, indent=4)  # I think this prints a whole bunch of extra parameters associated with pythonic/SQLAlchemy info...
 
 ################################################################################
 # Mixin Column Classes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "EFIJobExecutor"
-version = "0.0.2"
+version = "0.0.3"
 authors = [
   { name="Russell B. Davidson", email="rbdavid@illinois.edu" },
   { name="Nils Oberg", email="noberg@illinois.edu" },

--- a/tests/01_constants_test.py
+++ b/tests/01_constants_test.py
@@ -23,9 +23,9 @@ test_data = [
     pytest.param("archived", Status.ARCHIVED)
 ] 
 @pytest.mark.parametrize("Status_str, Status_flag", test_data)
-def test_getStatus(Status_str, Status_flag):
-    """ Testing wrapper function for the Status.getStatus method """
-    assert Status.getStatus(Status_str) == Status_flag
+def test_getFlag(Status_str, Status_flag):
+    """ Testing wrapper function for the Status.getFlag method """
+    assert Status.getFlag(Status_str) == Status_flag
 
 test_data = [
     # check membership in Status.INCOMPLETE


### PR DESCRIPTION
- [x] As of 2025/06/09, mirror the efi-web Job table in columns as well as the single table inheritance schema. There are slight deviations only due to differences in Doctrine and SQLAlchemy setup for the table inheritance. 
- [x] Clean up Status Flag object. 
- [ ] Implement a rudimentary taskStrategies that uses the various Job subtypes to prepare input parameter files. 